### PR TITLE
Make the startup the cluster version agnostic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM exasol/docker-db:latest
+FROM exasol/docker-db:latest-7.0
 
 WORKDIR /exa
 COPY . .

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sh /usr/opt/EXASuite-7/EXAClusterOS-7.0.10/docker/entrypoint.sh init-sc &
+sh /usr/opt/EXASuite-7/EXAClusterOS-$EXA_OS_VERSION/docker/entrypoint.sh init-sc &
 
 echo "Waiting for 45 seconds to let the exasol cluster go up"
 sleep 45


### PR DESCRIPTION
Since the base image was based on the latest label,
the cluster startup script path can change.

Looking at the image environment I realized there
are some environment variables that give the current
version so I changed the first row into the startup.sh
to use one of them instead of hardcoding the path.

Example of the available environment variables
```
...
EXA_RE_VERSION=7.0.14
EXA_OS_VERSION=7.0.14
SHLVL=1
HOME=/root
EXA_DB_VERSION=7.0.14
...
```

In addition, I changed the base image to be `latest-7.0` since `latest` now is 7.1